### PR TITLE
Update Twine2.download.recipe

### DIFF
--- a/Twine/Twine2.download.recipe
+++ b/Twine/Twine2.download.recipe
@@ -2,51 +2,45 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the latest version of Twine 2.</string>
-	<key>Identifier</key>
-	<string>com.github.denmoff.download.Twine2</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>Twine 2</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.6.1</string>
-	<key>Process</key>
+        <key>Description</key>
+        <string>Downloads the latest version of Twine 2.</string>
+        <key>Identifier</key>
+        <string>com.github.denmoff.download.Twine2</string>
+        <key>Input</key>
+        <dict>
+                <key>NAME</key>
+                <string>Twine 2</string>
+        </dict>
+        <key>MinimumVersion</key>
+        <string>0.6.1</string>
+        <key>Process</key>
         <array>
-	<dict>
-            <key>Processor</key>
-            <string>GitHubReleasesInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-               <key>asset_regex</key>
-               <string>^twine_2.*?_osx.zip$</string>
-               <key>github_repo</key>
-               <string>klembot/twinejs</string>
-	       <key>sort_by_highest_tag_names</key>
-               <true/>
-            </dict>
-        </dict>
-        <dict>
-        	<key>Processor</key>
-        	<string>URLDownloader</string>
-        </dict>
-       <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>purge_destination</key>
-                <true/>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/App</string>
-            </dict>
-        </dict>
-        <dict>
-	<key>Processor</key>
-	<string>EndOfCheckPhase</string>
-        </dict>
+                <dict>
+                        <key>Processor</key>
+                        <string>GitHubReleasesInfoProvider</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>asset_regex</key>
+                                <string>^twine_2.*?_macos.dmg$</string>
+                                <key>github_repo</key>
+                                <string>klembot/twinejs</string>
+                                <key>sort_by_highest_tag_names</key>
+                                <true/>
+                        </dict>
+                </dict>
+                <dict>
+                        <key>Processor</key>
+                        <string>URLDownloader</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>url</key>
+                                <string>%url%</string>
+                        </dict>
+                </dict>
+                <dict>
+                        <key>Processor</key>
+                        <string>EndOfCheckPhase</string>
+                </dict>
         </array>
 </dict>
 </plist>


### PR DESCRIPTION
Developer changed from .zip to .dmg filetype for macOS.