### PR TITLE
Update Twine2.munki.recipe

### DIFF
--- a/Twine/Twine2.munki.recipe
+++ b/Twine/Twine2.munki.recipe
@@ -2,77 +2,53 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.2 (https://github.com/homebysix/recipe-robot)</string>
-	<key>Description</key>
-	<string>Downloads the latest version of Twine 2 and imports it into Munki.</string>
-	<key>Identifier</key>
-	<string>com.github.denmoff.munki.Twine2</string>
-	<key>Input</key>
-	<dict>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/%NAME%</string>
-		<key>NAME</key>
-		<string>Twine</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>description</key>
-			<string>Twine is an open-source tool for telling interactive, nonlinear stories.</string>
-			<key>developer</key>
-			<string>Leon Arnott</string>
-			<key>display_name</key>
-			<string>Twine 2</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-		</dict>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.6.1</string>
-	<key>ParentRecipe</key>
-	<string>com.github.denmoff.download.Twine2</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%dmg_path%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-		</dict>
-	</array>
+        <key>Comment</key>
+        <string>Created with Recipe Robot v1.0.2 (https://github.com/homebysix/recipe-robot)</string>
+        <key>Description</key>
+        <string>Downloads the latest version of Twine 2 and imports it into Munki.</string>
+        <key>Identifier</key>
+        <string>com.github.denmoff.munki.Twine2</string>
+        <key>Input</key>
+        <dict>
+                <key>MUNKI_REPO_SUBDIR</key>
+                <string>apps/%NAME%</string>
+                <key>NAME</key>
+                <string>Twine</string>
+                <key>pkginfo</key>
+                <dict>
+                        <key>catalogs</key>
+                        <array>
+                                <string>testing</string>
+                        </array>
+                        <key>description</key>
+                        <string>Twine is an open-source tool for telling interactive, nonlinear stories.</string>
+                        <key>developer</key>
+                        <string>Leon Arnott</string>
+                        <key>display_name</key>
+                        <string>Twine 2</string>
+                        <key>name</key>
+                        <string>%NAME%</string>
+                        <key>unattended_install</key>
+                        <true/>
+                </dict>
+        </dict>
+        <key>MinimumVersion</key>
+        <string>0.6.1</string>
+        <key>ParentRecipe</key>
+        <string>com.github.denmoff.download.Twine2</string>
+        <key>Process</key>
+        <array>
+                <dict>
+                        <key>Processor</key>
+                        <string>MunkiImporter</string>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>pkg_path</key>
+                                <string>%pathname%</string>
+                                <key>repo_subdirectory</key>
+                                <string>%MUNKI_REPO_SUBDIR%</string>
+                        </dict>
+                </dict>
+        </array>
 </dict>
 </plist>


### PR DESCRIPTION
Unarchiver and DmgCreator no longer necessary, see https://github.com/autopkg/denmoff-recipes/pull/6