### PR TITLE
Update Twine2.download.recipe

### DIFF
--- a/Twine/Twine2.download.recipe
+++ b/Twine/Twine2.download.recipe
@@ -21,7 +21,7 @@
                         <key>Arguments</key>
                         <dict>
                                 <key>asset_regex</key>
-                                <string>^twine_2.*?_macos.dmg$</string>
+                                <string>(T|t)wine*.2.([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)-macOS\.dmg$</string>
                                 <key>github_repo</key>
                                 <string>klembot/twinejs</string>
                                 <key>sort_by_highest_tag_names</key>


### PR DESCRIPTION
Hi, @denmoff 

This PR has some updated regex to account for variations in the file name. The current regex is only able to match with version `2.3.16`

Output from a successful -v run 

```
autopkg run -v /Users/paul.cossey/Documents/GitHub/AutoPkg\ Repos/denmoff-recipes/Twine/Twine2.munki.recipe 
Looking for com.github.denmoff.download.Twine2...
Did not find com.github.denmoff.download.Twine2 in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.denmoff.download.Twine2...
Found com.github.denmoff.download.Twine2 in recipe map
**load_recipe time: 0.0037004169998908765
Processing /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/denmoff-recipes/Twine/Twine2.munki.recipe...
WARNING: /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/denmoff-recipes/Twine/Twine2.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
WARNING: This is an unathenticated Github session, some API features may not work
GitHubReleasesInfoProvider: Matched regex '(T|t)wine*.2.([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)-macOS\.dmg$' among asset(s): Twine-2.8.0-macOS.dmg
GitHubReleasesInfoProvider: Selected asset 'Twine-2.8.0-macOS.dmg' from tag '2.8.0' at url https://github.com/klembot/twinejs/releases/download/2.8.0/Twine-2.8.0-macOS.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 27 Nov 2023 16:24:49 GMT
URLDownloader: Storing new ETag header: "0x8DBEF6560AA6962"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.denmoff.munki.Twine2/downloads/Twine-2.8.0-macOS.dmg
EndOfCheckPhase
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Twine/Twine-2.8.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Twine/Twine-2.8.0-macOS-2.8.0__1.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.denmoff.munki.Twine2/receipts/Twine2.munki-receipt-20231128-155246.plist

The following new items were downloaded:
    Download Path                                                                                             
    -------------                                                                                             
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.denmoff.munki.Twine2/downloads/Twine-2.8.0-macOS.dmg  

The following new items were imported into Munki:
    Name   Version  Catalogs  Pkginfo Path                     Pkg Repo Path                              Icon Repo Path  
    ----   -------  --------  ------------                     -------------                              --------------  
    Twine  2.8.0    testing   apps/Twine/Twine-2.8.0__1.plist  apps/Twine/Twine-2.8.0-macOS-2.8.0__1.dmg 
``` 