### PR TITLE
Deprecate non-functional Twine1 recipes

### DIFF
--- a/Twine/Twine.download.recipe
+++ b/Twine/Twine.download.recipe
@@ -14,7 +14,16 @@
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>Process</key>
-        <array>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Twine2 recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the non-functional Twine 1 recipes.
