### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Twine/Twine.download.recipe
+++ b/Twine/Twine.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://twinery.org</string>
+                <string>https://twinery.org</string>
                 <key>re_pattern</key>
                 <string>a href=\"(/downloads/twine_1.4.2_osx.zip)</string>
             </dict>
@@ -32,7 +32,7 @@
         	<key>Arguments</key>
         	<dict>
         	   <key>url</key>
-        	   <string>http://twinery.org%match%</string>
+        	   <string>https://twinery.org%match%</string>
         	   <key>filename</key>
         	   <string>%NAME%.zip</string>
         	</dict>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._